### PR TITLE
Standardize and dedupe week 6 pools

### DIFF
--- a/snc/pools/lambardi/week6.txt
+++ b/snc/pools/lambardi/week6.txt
@@ -1,147 +1,106 @@
-Deck
-1 Shakedown Heavy (SNC) 95
-1 Plasma Jockey (SNC) 115
-1 Murder (SNC) 88
-1 Fake Your Own Death (SNC) 79
-2 Corrupt Court Official (SNC) 70
-1 Light 'Em Up (SNC) 113
-1 Unlucky Witness (SNC) 128
-2 Sticky Fingers (SNC) 124
-1 Riveteers Decoy (SNC) 156
-2 Torch Breath (SNC) 127
-4 Swamp (SNC) 267
-1 Tramway Station (SNC) 258
-1 Caldaia Strongarm (SNC) 138
-2 Crew Captain (SNC) 180
-2 Body Dropper (SNC) 168
-2 Racers' Ring (SNC) 253
-1 Security Rhox (SNC) 220
-5 Mountain (SNC) 269
-2 Forest (SNC) 271
-1 Riveteers Overlook (SNC) 255
-1 Cabaretti Courtyard (SNC) 249
-1 Jewel Thief (SNC) 151
-1 Fight Rigging (SNC) 145
-1 Ziatora's Envoy (SNC) 232
-1 Quick-Draw Dagger (SNC) 243
-1 Pyre-Sledge Arsonist (SNC) 118
-
-Sideboard
-1 Light 'Em Up (SNC) 113
-1 Attended Socialite (SNC) 133
-2 Waterfront District (SNC) 259
-1 Aven Heartstabber (SNC) 166
-1 Snooping Newsie (SNC) 222
-1 Obscura Storefront (SNC) 252
-1 Evelyn, the Covetous (SNC) 184
-1 Shattered Seraph (SNC) 221
-1 Hold for Ransom (SNC) 16
-2 Gathering Throng (SNC) 13
-1 Buy Your Silence (SNC) 6
-1 Speakeasy Server (SNC) 32
-2 Brokers Veteran (SNC) 36
-1 Obscura Initiate (SNC) 50
-1 Paragon of Modernity (SNC) 242
-1 Darling of the Masses (SNC) 181
-2 Sky Crier (SNC) 31
-2 Echo Inspector (SNC) 40
-2 Raffine's Guidance (SNC) 25
-1 Prizefight (SNC) 154
-1 Demon's Due (SNC) 75
-3 A Little Chat (SNC) 47
-2 Celebrity Fencer (SNC) 7
-1 Security Bypass (SNC) 59
-1 Witty Roastmaster (SNC) 131
-1 Social Climber (SNC) 157
-1 Extract the Truth (SNC) 78
-1 Raffine's Informant (SNC) 26
-1 Rakish Revelers (SNC) 214
-1 Disdainful Stroke (SNC) 39
-2 Tainted Indulgence (SNC) 227
-1 Soul of Emancipation (SNC) 223
-1 Masked Bandits (SNC) 201
-2 Rooftop Nuisance (SNC) 57
-1 Halo Scarab (SNC) 239
-1 Revel Ruiner (SNC) 91
-1 Glittering Stockpile (SNC) 107
-1 Warm Welcome (SNC) 164
-1 Voice of the Vermin (SNC) 163
-1 Graveyard Shift (SNC) 81
-1 Capenna Express (SNC) 139
-1 Revelation of Power (SNC) 28
-1 Brokers Initiate (SNC) 5
-1 Luxurious Libation (SNC) 152
-1 Antagonize
-2 Botanical Plaza
-1 Civic Gardener
-1 Crew Captain
-1 Crooked Custodian
-1 Echo Inspector
-1 Exhibition Magician
-1 Island
-1 Jinnie Fay, Jetmir's Second
-1 Patch Up
-1 Skybridge Towers
-1 Strangle
-1 Tavern Swindler
-1 Tramway Station
-1 A Little Chat
-1 Civil Servant
-1 Crooked Custodian
-1 Girder Goons
-1 Hypnotic Grifter
-1 Island
-1 Join the Maestros
-1 Knockout Blow
-1 Ledger Shredder
-1 Prizefight
-1 Rhox Pummeler
-1 Shattered Seraph
-1 Social Climber
-1 Tramway Station
-1 Vampire Scrivener
-1 Botanical Plaza
-1 Case the Joint
-1 Island
-1 Jackhammer
-1 Join the Maestros
-1 Murder
-1 Ob Nixilis, the Adversary
-1 Obscura Charm
-1 Ominous Parcel
-1 Racers' Ring
-1 Raffine's Guidance
-1 Rhox Pummeler
-1 Riveteers Decoy
-1 Security Rhox
-1 Swamp
-1 Body Dropper
-1 Caldaia Strongarm
-1 Cormela, Glamour Thief
-1 Dapper Shieldmate
-1 Daring Escape
-1 Darling of the Masses
-1 Echo Inspector
-1 Extract the Truth
-1 Forge Boss
-1 Masked Bandits
-1 Metropolis Angel
-1 Obscura Initiate
-1 Racers' Ring
-1 Swamp
-1 Ziatora, the Incinerator
-1 Body Dropper
-1 Buy Your Silence
-1 Cabaretti Courtyard
-1 Deal Gone Bad
-1 Island
+1 Brokers Initiate
+3 Raffine's Guidance
+1 Hold for Ransom
+1 Raffine's Informant
+1 Revelation of Power
+2 Sky Crier
+2 Gathering Throng
 1 Kill Shot
-1 Maestros Ascendancy
-1 Midnight Assassin
-1 Ominous Parcel
+1 Knockout Blow
+1 Patch Up
+2 Celebrity Fencer
+1 Dapper Shieldmate
+2 Buy Your Silence
+1 Speakeasy Server
+1 Hypnotic Grifter
+4 A Little Chat
+2 Brokers Veteran
+1 Disdainful Stroke
+1 Ledger Shredder
+1 Security Bypass
+2 Obscura Initiate
 1 Public Enemy
-1 Rakish Revelers
-1 Riveteers Charm
-1 Shattered Seraph
+2 Rooftop Nuisance
+1 Case the Joint
+4 Echo Inspector
 1 Sleep with the Fishes
-1 Social Climber
+2 Corrupt Court Official
+2 Crooked Custodian
+2 Extract the Truth
+1 Fake Your Own Death
+1 Tavern Swindler
+1 Midnight Assassin
+2 Murder
+1 Shakedown Heavy
+1 Deal Gone Bad
+1 Demon's Due
+1 Revel Ruiner
+1 Girder Goons
+1 Graveyard Shift
+2 Join the Maestros
+1 Vampire Scrivener
+1 Daring Escape
+2 Sticky Fingers
+1 Strangle
+1 Unlucky Witness
+1 Antagonize
+1 Jackhammer
+2 Light 'Em Up
+1 Exhibition Magician
+1 Glittering Stockpile
+1 Pyre-Sledge Arsonist
+1 Witty Roastmaster
+1 Plasma Jockey
+2 Torch Breath
+1 Attended Socialite
+1 Civic Gardener
+2 Prizefight
+2 Riveteers Decoy
+1 Fight Rigging
+1 Jewel Thief
+3 Social Climber
+1 Warm Welcome
+1 Capenna Express
+1 Voice of the Vermin
+2 Caldaia Strongarm
+2 Rhox Pummeler
+1 Luxurious Libation
+1 Metropolis Angel
+1 Aven Heartstabber
+1 Snooping Newsie
+2 Tainted Indulgence
+4 Body Dropper
+1 Ob Nixilis, the Adversary
+1 Forge Boss
+2 Security Rhox
+1 Civil Servant
+2 Darling of the Masses
+1 Soul of Emancipation
+1 Obscura Charm
+3 Shattered Seraph
+1 Maestros Ascendancy
+1 Cormela, Glamour Thief
+1 Evelyn, the Covetous
+3 Crew Captain
+1 Riveteers Charm
+1 Ziatora's Envoy
+2 Masked Bandits
+1 Ziatora, the Incinerator
+1 Jinnie Fay, Jetmir's Second
+2 Rakish Revelers
+2 Ominous Parcel
+1 Halo Scarab
+1 Quick-Draw Dagger
+1 Paragon of Modernity
+3 Botanical Plaza
+2 Cabaretti Courtyard
+1 Obscura Storefront
+4 Racers' Ring
+1 Riveteers Overlook
+1 Skybridge Towers
+3 Tramway Station
+2 Waterfront District
+2 Forest
+4 Island
+5 Mountain
+6 Swamp

--- a/snc/pools/lonny/week6.txt
+++ b/snc/pools/lonny/week6.txt
@@ -1,149 +1,117 @@
-1 Depopulate
-1 Errant, Street Artist
-1 Topiary Stomper
-1 Corpse Explosion
-1 Riveteers Ascendancy
-1 Jetmir's Garden
-1 Illuminator Virtuoso
-1 Refuse to Yield
-1 Patch Up
-1 Ballroom Brawlers
-1 Wingshield Agent
-1 Unlucky Witness
-1 Involuntary Employment
-1 Cleanup Crew
-1 Luxurious Libation
-1 Exotic Pets
-1 Security Rhox
-1 Disciplined Duelist
-1 Nimble Larcenist
-1 Maestros Charm
-1 Crew Captain
-2 Riveteers Charm
-1 Arc Spitter
-1 Boon of Safety
-1 Brokers Initiate
+2 Boon of Safety
+3 Brokers Initiate
 1 Raffine's Guidance
-1 Backup Agent
-1 Hold for Ransom
+2 Backup Agent
+1 Citizen's Crowbar
+2 Hold for Ransom
+1 Illuminator Virtuoso
+1 Raffine's Informant
+1 Refuse to Yield
 1 Revelation of Power
-1 Sky Crier
+2 Sky Crier
+1 Gathering Throng
+1 Halo Fountain
 1 Inspiring Overseer
+1 Patch Up
+1 Rumor Gatherer
 2 Celebrity Fencer
-1 Speakeasy Server
+1 Depopulate
+1 Ballroom Brawlers
+2 Speakeasy Server
+1 Errant, Street Artist
 1 Backstreet Bruiser
+1 Disdainful Stroke
 1 Security Bypass
 1 Majestic Metamorphosis
-2 Obscura Initiate
+3 Obscura Initiate
 1 Psionic Snoop
+1 Wingshield Agent
 1 Case the Joint
-1 Echo Inspector
+2 Echo Inspector
+1 Reservoir Kraken
 1 Run Out of Town
-1 Sewer Crocodile
+2 Sewer Crocodile
+1 Cutthroat Contender
 1 Corrupt Court Official
-1 Extract the Truth
-1 Incriminate
+1 Crooked Custodian
+2 Extract the Truth
+3 Incriminate
 1 Dig Up the Body
+1 Maestros Initiate
+1 Midnight Assassin
 1 Demon's Due
 1 Revel Ruiner
 1 Girder Goons
-2 Join the Maestros
+3 Join the Maestros
+1 Dusk Mangler
+1 Daring Escape
 2 Goldhound
+1 Sticky Fingers
+1 Unlucky Witness
 1 Antagonize
 1 Jackhammer
-1 Mayhem Patrol
-1 Plasma Jockey
-1 Wrecking Crew
+2 Mayhem Patrol
+1 Call In a Professional
+1 Exhibition Magician
+2 Involuntary Employment
+2 Plasma Jockey
+1 Pugnacious Pugilist
+2 Wrecking Crew
+1 Torch Breath
 1 Cabaretti Initiate
-1 Prizefight
+1 For the Family
+1 Attended Socialite
+2 Prizefight
 1 High-Rise Sawjack
 2 Most Wanted
 1 Social Climber
+1 Topiary Stomper
 1 Capenna Express
 1 Glittermonger
 2 Caldaia Strongarm
-1 Rhox Pummeler
+1 Cleanup Crew
+3 Rhox Pummeler
+1 Luxurious Libation
+1 Celestial Regulator
+1 Exotic Pets
+1 Snooping Newsie
+2 Syndicate Infiltrator
+1 Body Dropper
+1 Corpse Explosion
+1 Security Rhox
 1 Civil Servant
-2 Ominous Parcel
-1 Quick-Draw Dagger
+2 Brokers Charm
+1 Disciplined Duelist
+1 Lagrella, the Magpie
+2 Soul of Emancipation
+1 Nimble Larcenist
+1 Corpse Appraiser
+1 Maestros Charm
+1 Glamorous Outlaw
+1 Crew Captain
+1 Riveteers Ascendancy
+2 Riveteers Charm
+1 Unleash the Inferno
+1 Cabaretti Charm
+1 Rakish Revelers
+1 Arc Spitter
+4 Ominous Parcel
+1 Gilded Pinions
+1 Chrome Cat
+3 Quick-Draw Dagger
+1 Brass Knuckles
+1 Paragon of Modernity
 1 Botanical Plaza
 1 Brokers Hideout
+1 Jetmir's Garden
 2 Maestros Theater
 1 Obscura Storefront
-1 Tramway Station
-2 Waterfront District
-1 Cabaretti Charm
-1 Cutthroat Contender
-1 Daring Escape
-1 Echo Inspector
-1 Exhibition Magician
-1 For the Family
-1 Involuntary Employment
-1 Ominous Parcel
-1 Plains
-1 Plasma Jockey
-1 Racers' Ring
-1 Rakish Revelers
-1 Snooping Newsie
-1 Soul of Emancipation
-1 Syndicate Infiltrator
-1 Attended Socialite
-1 Boon of Safety
-1 Brokers Charm
-1 Celestial Regulator
-1 Citizen's Crowbar
-1 Crooked Custodian
-1 Forest
-1 Gilded Pinions
-1 Hold for Ransom
-1 Join the Maestros
-1 Lagrella, the Magpie
-1 Mayhem Patrol
+2 Racers' Ring
 1 Riveteers Overlook
-1 Speakeasy Server
-1 Unleash the Inferno
-1 Backup Agent
-1 Brokers Charm
-1 Call In a Professional
-1 Chrome Cat
-1 Disdainful Stroke
-1 Dusk Mangler
-1 Halo Fountain
-1 Incriminate
-1 Mountain
-1 Quick-Draw Dagger
-1 Racers' Ring
-1 Raffine's Informant
-1 Sewer Crocodile
 1 Skybridge Towers
-1 Tramway Station
-1 Body Dropper
-1 Brass Knuckles
-1 Brokers Initiate
-1 Extract the Truth
-1 Gathering Throng
-1 Glamorous Outlaw
-1 Incriminate
-1 Pugnacious Pugilist
-1 Quick-Draw Dagger
-1 Rhox Pummeler
-1 Sky Crier
-1 Soul of Emancipation
+2 Tramway Station
+3 Waterfront District
+1 Forest
+2 Mountain
+1 Plains
 1 Swamp
-1 Torch Breath
-1 Wrecking Crew
-1 Brokers Initiate
-1 Corpse Appraiser
-1 Maestros Initiate
-1 Midnight Assassin
-1 Mountain
-1 Obscura Initiate
-1 Ominous Parcel
-1 Paragon of Modernity
-1 Prizefight
-1 Reservoir Kraken
-1 Rhox Pummeler
-1 Rumor Gatherer
-1 Sticky Fingers
-1 Syndicate Infiltrator
-1 Waterfront District

--- a/snc/pools/mc/week6.txt
+++ b/snc/pools/mc/week6.txt
@@ -1,146 +1,110 @@
-2 Boon of Safety (SNC) 4
-1 Brokers Initiate (SNC) 5
-1 Raffine's Guidance (SNC) 25
-1 Hold for Ransom (SNC) 16
-1 Revelation of Power (SNC) 28
-1 Gathering Throng (SNC) 13
-1 Inspiring Overseer (SNC) 18
-1 Knockout Blow (SNC) 20
-1 Rumor Gatherer (SNC) 29
-1 Celebrity Fencer (SNC) 7
-1 Dapper Shieldmate (SNC) 9
-1 Angelic Observer (SNC) 1
-1 Expendable Lackey (SNC) 43
-1 Slip Out the Back (SNC) 62
-1 Brokers Veteran (SNC) 36
-1 Disdainful Stroke (SNC) 39
-2 Security Bypass (SNC) 59
-1 Case the Joint (SNC) 37
-1 Psychic Pickpocket (SNC) 54
-1 Cutthroat Contender (SNC) 73
-1 Corrupt Court Official (SNC) 70
-1 Crooked Custodian (SNC) 71
-1 Extract the Truth (SNC) 78
-1 Maestros Initiate (SNC) 86
-1 Deal Gone Bad (SNC) 74
-1 Girder Goons (SNC) 80
-1 Join the Maestros (SNC) 85
-1 Shadow of Mortality (SNC) 94
-1 Daring Escape (SNC) 104
-1 Goldhound (SNC) 108
-2 Strangle (SNC) 125
-1 Light 'Em Up (SNC) 113
-1 Mayhem Patrol (SNC) 114
-2 Riveteers Initiate (SNC) 120
-1 Riveteers Requisitioner (SNC) 121
-1 Exhibition Magician (SNC) 106
-1 Pyre-Sledge Arsonist (SNC) 118
-2 Big Score (SNC) 102
-1 Arcane Bombardment (SNC) 101
-1 Torch Breath (SNC) 127
-1 For the Family (SNC) 146
-1 Civic Gardener (SNC) 140
-1 Prizefight (SNC) 154
-1 Broken Wings (SNC) 136
-1 Jewel Thief (SNC) 151
-1 Most Wanted (SNC) 153
-1 Social Climber (SNC) 157
-1 Rhox Pummeler (SNC) 155
-1 Tainted Indulgence (SNC) 227
-1 Body Dropper (SNC) 168
-1 Fatal Grudge (SNC) 187
-1 Civil Servant (SNC) 176
-1 Obscura Charm (SNC) 208
-2 Obscura Interceptor (SNC) 209
-1 Maestros Charm (SNC) 199
-1 Glamorous Outlaw (SNC) 190
-2 Mr. Orfeo, the Boulder (SNC) 204
-1 Masked Bandits (SNC) 201
-1 Cabaretti Ascendancy (SNC) 172
-1 Incandescent Aria (SNC) 192
-3 Rakish Revelers (SNC) 214
-1 Brokers Charm (SNC) 171
-1 Lagrella, the Magpie (SNC) 196
-1 Spara's Adjudicators (SNC) 224
-2 Cabaretti Courtyard (SNC) 249
-2 Maestros Theater (SNC) 251
-1 Obscura Storefront (SNC) 252
-1 Riveteers Overlook (SNC) 255
-2 Cement Shoes (SNC) 235
-2 Gilded Pinions (SNC) 238
-1 Paragon of Modernity (SNC) 242
-1 Civic Gardener
-1 Cleanup Crew
-1 Cutthroat Contender
-1 Dig Up the Body
-1 For the Family
-1 Forest
-1 Gilded Pinions
-1 Majestic Metamorphosis
-1 Plasma Jockey
-1 Quick-Draw Dagger
-1 Rooftop Nuisance
-1 Run Out of Town
-1 Suspicious Bookcase
-1 Take to the Streets
-1 Tenacious Underdog
-1 An Offer You Can't Refuse
-1 Capenna Express
-1 Corrupt Court Official
-1 Gathering Throng
-1 Girder Goons
-1 Maestros Initiate
-1 Mountain
-1 Patch Up
-1 Run Out of Town
-1 Skybridge Towers
-1 Sticky Fingers
-1 Tavern Swindler
-1 Void Rend
-1 Waterfront District
-1 Witty Roastmaster
-1 A Little Chat
-1 Cabaretti Initiate
-1 Celestial Regulator
-1 Corrupt Court Official
-1 Crooked Custodian
-1 Darling of the Masses
-1 For the Family
-1 Girder Goons
+2 Boon of Safety
+1 Brokers Initiate
+2 Raffine's Guidance
+1 Hold for Ransom
 1 Illuminator Virtuoso
-1 Mayhem Patrol
-1 Plains
-1 Raffine's Guidance
-1 Rogues' Gallery
-1 Skybridge Towers
-1 Tenacious Underdog
-1 Body Dropper
-1 Brazen Upstart
-1 Celestial Regulator
-1 Civil Servant
-1 Demon's Due
-1 Glittering Stockpile
-1 Goldhound
-1 Luxurious Libation
-1 Make Disappear
-1 Plains
-1 Prizefight
-1 Revel Ruiner
-1 Riveteers Overlook
-1 Structural Assault
-1 Tramway Station
+1 Revelation of Power
+2 Gathering Throng
+1 Inspiring Overseer
+1 Knockout Blow
+1 Patch Up
+1 Rumor Gatherer
+1 Celebrity Fencer
+1 Dapper Shieldmate
 1 Buy Your Silence
-1 Cabaretti Initiate
-1 Capenna Express
-1 Corrupt Court Official
-1 Disdainful Stroke
-1 Girder Goons
-1 Glittering Stockpile
-1 Make Disappear
-1 Masked Bandits
-1 Plains
-1 Pyre-Sledge Arsonist
-1 Raffine's Tower
-1 Run Out of Town
-1 Torch Breath
+1 Angelic Observer
+1 An Offer You Can't Refuse
+1 Expendable Lackey
+1 Slip Out the Back
+1 A Little Chat
+1 Brokers Veteran
+2 Disdainful Stroke
+2 Make Disappear
+2 Security Bypass
+1 Majestic Metamorphosis
+1 Rooftop Nuisance
+1 Case the Joint
+3 Run Out of Town
+1 Psychic Pickpocket
+2 Cutthroat Contender
+4 Corrupt Court Official
+2 Crooked Custodian
+1 Extract the Truth
+1 Tavern Swindler
+2 Tenacious Underdog
+1 Dig Up the Body
+2 Maestros Initiate
+1 Rogues' Gallery
+1 Deal Gone Bad
+1 Demon's Due
+1 Revel Ruiner
+4 Girder Goons
+1 Join the Maestros
+1 Shadow of Mortality
+1 Daring Escape
+2 Goldhound
+1 Sticky Fingers
+2 Strangle
+1 Light 'Em Up
+2 Mayhem Patrol
+2 Riveteers Initiate
+1 Riveteers Requisitioner
+1 Exhibition Magician
+2 Glittering Stockpile
+2 Pyre-Sledge Arsonist
+1 Witty Roastmaster
+2 Big Score
+1 Plasma Jockey
+1 Structural Assault
+1 Arcane Bombardment
+2 Torch Breath
+2 Cabaretti Initiate
+3 For the Family
+2 Civic Gardener
+2 Prizefight
+1 Broken Wings
+1 Jewel Thief
+1 Most Wanted
+1 Social Climber
 1 Warm Welcome
+2 Capenna Express
+1 Take to the Streets
+1 Cleanup Crew
+1 Rhox Pummeler
+1 Luxurious Libation
+2 Celestial Regulator
+1 Tainted Indulgence
+2 Body Dropper
+1 Fatal Grudge
+2 Civil Servant
+1 Darling of the Masses
+1 Brokers Charm
+1 Lagrella, the Magpie
+1 Spara's Adjudicators
+1 Obscura Charm
+1 Void Rend
+2 Obscura Interceptor
+1 Maestros Charm
+1 Glamorous Outlaw
+2 Mr. Orfeo, the Boulder
+2 Masked Bandits
+1 Brazen Upstart
+1 Cabaretti Ascendancy
+1 Incandescent Aria
+3 Rakish Revelers
+2 Cement Shoes
+3 Gilded Pinions
+1 Suspicious Bookcase
+1 Quick-Draw Dagger
+1 Paragon of Modernity
+2 Cabaretti Courtyard
+2 Maestros Theater
+1 Obscura Storefront
+1 Raffine's Tower
+2 Riveteers Overlook
+2 Skybridge Towers
+1 Tramway Station
+1 Waterfront District
+1 Forest
+1 Mountain
+3 Plains

--- a/snc/pools/mettledrum/week6.txt
+++ b/snc/pools/mettledrum/week6.txt
@@ -1,144 +1,111 @@
-2 Tramway Station (SNC) 258
-1 Fatal Grudge (SNC) 187
-1 Mountain (SNC) 269
-1 Swamp (SNC) 267
-1 Racers' Ring (SNC) 253
-2 Jetmir's Fixer (SNC) 194
-4 Island (SNC) 265
-1 Stimulus Package (SNC) 225
-1 Botanical Plaza (SNC) 247
-1 Ceremonial Groundbreaker (SNC) 175
-2 Plains (SNC) 263
-1 Shattered Seraph (SNC) 221
-1 Forest (SNC) 271
-1 Corpse Appraiser (SNC) 178
-1 Ziatora's Proving Ground (SNC) 261
-2 Riveteers Charm (SNC) 217
-1 Jinnie Fay, Jetmir's Second (SNC) 195
-1 Rakish Revelers (SNC) 214
-1 Rocco, Cabaretti Caterer (SNC) 218
-1 Spara's Adjudicators (SNC) 224
-1 Cabaretti Courtyard (SNC) 249
-1 Maestros Theater (SNC) 251
-1 Obscura Storefront (SNC) 252
-1 Quick-Draw Dagger (SNC) 243
-2 Paragon of Modernity (SNC) 242
-2 Raffine's Guidance (SNC) 25
-1 Illuminator Virtuoso (SNC) 17
-1 Revelation of Power (SNC) 28
-3 Sky Crier (SNC) 31
-1 Gathering Throng (SNC) 13
-1 Patch Up (SNC) 23
-1 Rumor Gatherer (SNC) 29
-1 Dapper Shieldmate (SNC) 9
-2 An Offer You Can't Refuse (SNC) 51
-1 Witness Protection (SNC) 66
-1 Backstreet Bruiser (SNC) 35
-2 Brokers Veteran (SNC) 36
-1 Make Disappear (SNC) 49
-1 Reservoir Kraken (SNC) 56
-2 Run Out of Town (SNC) 58
-1 Undercover Operative (SNC) 63
-1 Cutthroat Contender (SNC) 73
-1 Crooked Custodian (SNC) 71
-2 Incriminate (SNC) 84
-1 Tavern Swindler (SNC) 96
-1 Tenacious Underdog (SNC) 97
-1 Maestros Initiate (SNC) 86
-2 Deal Gone Bad (SNC) 74
-2 Girder Goons (SNC) 80
-1 Graveyard Shift (SNC) 81
-1 Vampire Scrivener (SNC) 98
-1 Sticky Fingers (SNC) 124
-1 Strangle (SNC) 125
-3 Antagonize (SNC) 100
-2 Jackhammer (SNC) 111
-1 Light 'Em Up (SNC) 113
-1 Riveteers Initiate (SNC) 120
-1 Call In a Professional (SNC) 103
-4 Exhibition Magician (SNC) 106
-1 Attended Socialite (SNC) 133
-1 Gala Greeters (SNC) 148
-1 Most Wanted (SNC) 153
-1 Social Climber (SNC) 157
-1 Warm Welcome (SNC) 164
-2 Capenna Express (SNC) 139
-1 Glittermonger (SNC) 149
-1 Freelance Muscle (SNC) 147
-1 Snooping Newsie (SNC) 222
-1 Syndicate Infiltrator (SNC) 226
-1 Antagonize
-1 Backup Agent
 1 Boon of Safety
-1 Broken Wings
-1 Chrome Cat
-1 Crew Captain
-1 Exotic Pets
-1 Faerie Vandal
-1 Fake Your Own Death
-1 Fleetfoot Dancer
-1 Inspiring Overseer
-1 Maestros Theater
-1 Revel Ruiner
-1 Swamp
-1 Waterfront District
 1 Brokers Initiate
-1 Caldaia Strongarm
+2 Raffine's Guidance
+2 Backup Agent
+1 Hold for Ransom
+1 Illuminator Virtuoso
+2 Raffine's Informant
+1 Revelation of Power
+3 Sky Crier
+1 Extraction Specialist
+1 Gathering Throng
+1 Inspiring Overseer
+1 Mage's Attendant
+1 Patch Up
+1 Rumor Gatherer
+1 Dapper Shieldmate
+2 An Offer You Can't Refuse
+1 Slip Out the Back
+1 Witness Protection
+1 Backstreet Bruiser
+2 Brokers Veteran
+1 Disdainful Stroke
+1 Faerie Vandal
+1 Make Disappear
+1 Majestic Metamorphosis
+1 Obscura Initiate
+1 Public Enemy
+1 Echo Inspector
+1 Reservoir Kraken
+2 Run Out of Town
+1 Undercover Operative
+2 Cutthroat Contender
+2 Crooked Custodian
+2 Fake Your Own Death
+3 Incriminate
+1 Tavern Swindler
+1 Tenacious Underdog
+1 Maestros Initiate
+2 Deal Gone Bad
+1 Demon's Due
+1 Revel Ruiner
+3 Girder Goons
+1 Graveyard Shift
+1 Vampire Scrivener
+1 Sticky Fingers
+2 Strangle
+4 Antagonize
+2 Jackhammer
+1 Light 'Em Up
+2 Riveteers Initiate
+1 Call In a Professional
+4 Exhibition Magician
+1 Witty Roastmaster
+1 Wrecking Crew
+1 For the Family
+3 Attended Socialite
 1 Civic Gardener
-1 Corpse Explosion
-1 Fake Your Own Death
-1 Forest
-1 High-Rise Sawjack
-1 Incriminate
-1 Lagrella, the Magpie
-1 Ominous Parcel
+1 Gala Greeters
 1 Prizefight
 1 Riveteers Decoy
-1 Riveteers Initiate
-1 Slip Out the Back
-1 Wrecking Crew
-1 Backup Agent
-1 Capenna Express
-1 Ceremonial Groundbreaker
-1 Cutthroat Contender
-1 Extraction Specialist
-1 Girder Goons
-1 Jetmir's Fixer
-1 Majestic Metamorphosis
-1 Most Wanted
-1 Mountain
-1 Mr. Orfeo, the Boulder
-1 Public Enemy
-1 Raffine's Informant
-1 Strangle
-1 Witty Roastmaster
-1 Attended Socialite
-1 Botanical Plaza
-1 Cabaretti Charm
-1 Cement Shoes
-1 Demon's Due
-1 For the Family
-1 Mr. Orfeo, the Boulder
-1 Ognis, the Dragon's Lash
-1 Plains
-1 Racers' Ring
-1 Raffine's Informant
-1 Shattered Seraph
-1 Spara's Adjudicators
-1 Tramway Station
-1 Waterfront District
-1 Attended Socialite
-1 Caldaia Strongarm
-1 Crooked Custodian
-1 Disciplined Duelist
-1 Disdainful Stroke
-1 Echo Inspector
-1 Hold for Ransom
-1 Jetmir's Fixer
-1 Mage's Attendant
-1 Masked Bandits
-1 Mr. Orfeo, the Boulder
-1 Obscura Initiate
-1 Plains
+1 Broken Wings
+1 High-Rise Sawjack
+2 Most Wanted
+1 Social Climber
+2 Warm Welcome
+3 Capenna Express
+1 Glittermonger
+2 Caldaia Strongarm
+1 Freelance Muscle
 1 Scheming Fence
-1 Warm Welcome
+1 Exotic Pets
+1 Snooping Newsie
+1 Syndicate Infiltrator
+1 Fatal Grudge
+1 Corpse Explosion
+4 Jetmir's Fixer
+1 Stimulus Package
+2 Ceremonial Groundbreaker
+1 Disciplined Duelist
+1 Lagrella, the Magpie
+2 Spara's Adjudicators
+2 Shattered Seraph
+1 Corpse Appraiser
+1 Crew Captain
+2 Riveteers Charm
+3 Mr. Orfeo, the Boulder
+1 Ognis, the Dragon's Lash
+1 Masked Bandits
+1 Cabaretti Charm
+1 Jinnie Fay, Jetmir's Second
+1 Fleetfoot Dancer
+1 Rakish Revelers
+1 Rocco, Cabaretti Caterer
+1 Cement Shoes
+1 Ominous Parcel
+1 Chrome Cat
+1 Quick-Draw Dagger
+2 Paragon of Modernity
+2 Botanical Plaza
+1 Cabaretti Courtyard
+2 Maestros Theater
+1 Obscura Storefront
+2 Racers' Ring
+3 Tramway Station
+2 Waterfront District
+1 Ziatora's Proving Ground
+2 Forest
+4 Island
+2 Mountain
+4 Plains
+2 Swamp

--- a/snc/pools/redfort/week6.txt
+++ b/snc/pools/redfort/week6.txt
@@ -1,149 +1,109 @@
-1 Boon of Safety (SNC) 4
-1 Strangle (SNC) 125
-1 Raffine's Guidance (SNC) 25
-1 Hold for Ransom (SNC) 16
-2 Raffine's Informant (SNC) 26
-1 Sky Crier (SNC) 31
-1 Gathering Throng (SNC) 13
-1 Swooping Protector (SNC) 33
-1 Ballroom Brawlers (SNC) 3
-1 Buy Your Silence (SNC) 6
-1 Speakeasy Server (SNC) 32
-1 Expendable Lackey (SNC) 43
-1 Unlucky Witness (SNC) 128
-1 Backstreet Bruiser (SNC) 35
-1 Faerie Vandal (SNC) 44
-1 Obscura Initiate (SNC) 50
-1 Psionic Snoop (SNC) 53
-1 Rooftop Nuisance (SNC) 57
-1 Cutthroat Contender (SNC) 73
-1 Antagonize (SNC) 100
-1 Grisly Sigil (SNC) 82
-1 Corrupt Court Official (SNC) 70
-1 Crooked Custodian (SNC) 71
-1 Murder (SNC) 88
-1 Deal Gone Bad (SNC) 74
-1 Demon's Due (SNC) 75
-1 Daring Escape (SNC) 104
-1 Sticky Fingers (SNC) 124
-1 Mayhem Patrol (SNC) 114
-1 Riveteers Initiate (SNC) 120
-1 Rob the Archives (SNC) 122
-1 Exhibition Magician (SNC) 106
-1 Witty Roastmaster (SNC) 131
-1 Hoard Hauler (SNC) 109
-1 Sizzling Soloist (SNC) 123
-1 Pugnacious Pugilist (SNC) 117
-1 Attended Socialite (SNC) 133
-1 Gala Greeters (SNC) 148
-1 Bouncer's Beatdown (SNC) 135
-1 Masked Bandits (SNC) 201
-2 Expendable Lackey (SNC) 43
-3 Quick-Draw Dagger (SNC) 243
-1 Rhox Pummeler (SNC) 155
-1 Demon's Due (SNC) 75
-1 Antagonize (SNC) 100
-1 Ziatora's Proving Ground (SNC) 261
-1 Most Wanted (SNC) 153
-1 Crooked Custodian (SNC) 71
-2 Riveteers Overlook (SNC) 255
-3 Warm Welcome (SNC) 164
-1 Disciplined Duelist (SNC) 182
-1 Fight Rigging (SNC) 145
-2 Corrupt Court Official (SNC) 70
-2 Snooping Newsie (SNC) 222
-1 Cabaretti Courtyard (SNC) 249
-1 Elegant Entourage (SNC) 143
-1 Fatal Grudge (SNC) 187
-1 Cleanup Crew (SNC) 141
-1 Obscura Initiate (SNC) 50
-1 Social Climber (SNC) 157
-2 Jetmir's Fixer (SNC) 194
-1 Botanical Plaza (SNC) 247
-1 Spara's Adjudicators (SNC) 224
-1 Waterfront District (SNC) 259
-1 Broken Wings (SNC) 136
-1 Mr. Orfeo, the Boulder (SNC) 204
-1 Freelance Muscle (SNC) 147
-1 Suspicious Bookcase (SNC) 245
-1 Topiary Stomper (SNC) 160
-1 Rakish Revelers (SNC) 214
-1 Maestros Ascendancy (SNC) 198
-1 Gilded Pinions (SNC) 238
-1 Rogues' Gallery (SNC) 92
-1 Brokers Charm (SNC) 171
-1 Broken Wings
-1 Call In a Professional
-1 Crooked Custodian
-1 Gilded Pinions
-1 Glittering Stockpile
-1 Join the Maestros
-1 Make Disappear
-1 Most Wanted
-1 Mountain
-1 Plasma Jockey
-1 Riveteers Initiate
-1 Shattered Seraph
-1 Soul of Emancipation
-1 Sticky Fingers
-1 Swooping Protector
-1 Attended Socialite
-1 Backstreet Bruiser
-1 Call In a Professional
-1 Civil Servant
-1 Corpse Appraiser
-1 Corrupt Court Official
-1 Fake Your Own Death
-1 Inspiring Overseer
-1 Jinnie Fay, Jetmir's Second
-1 Nimble Larcenist
-1 Obscura Initiate
-1 Plains
-1 Revelation of Power
-1 Rooftop Nuisance
-1 Witty Roastmaster
-1 Antagonize
+1 Boon of Safety
 1 Brokers Initiate
-1 Crew Captain
-1 Disdainful Stroke
-1 Freelance Muscle
-1 Halo Scarab
-1 Mayhem Patrol
-1 Midnight Assassin
-1 Mountain
-1 Public Enemy
-1 Raffine's Guidance
-1 Rakish Revelers
-1 Skybridge Towers
-1 Tramway Station
-1 Unleash the Inferno
-1 Chrome Cat
-1 Cormela, Glamour Thief
-1 Crew Captain
+2 Raffine's Guidance
+1 Hold for Ransom
+2 Raffine's Informant
+1 Revelation of Power
+1 Sky Crier
+1 Gathering Throng
+1 Inspiring Overseer
 1 Dapper Shieldmate
-1 Goldhound
-1 Jewel Thief
-1 Maestros Theater
-1 Meeting of the Five
-1 Most Wanted
-1 Murder
-1 Queza, Augur of Agonies
-1 Spara's Adjudicators
-1 Swamp
-1 Tramway Station
-1 Witness Protection
+2 Swooping Protector
+1 Ballroom Brawlers
+1 Buy Your Silence
+1 Speakeasy Server
 1 An Offer You Can't Refuse
+3 Expendable Lackey
+1 Witness Protection
+2 Backstreet Bruiser
+1 Disdainful Stroke
+1 Faerie Vandal
+1 Make Disappear
+3 Obscura Initiate
+1 Psionic Snoop
+1 Public Enemy
+2 Rooftop Nuisance
 1 Case the Joint
-1 Cleanup Crew
-1 Cutthroat Contender
-1 Join the Maestros
+2 Cutthroat Contender
+1 Grisly Sigil
+4 Corrupt Court Official
+3 Crooked Custodian
+1 Fake Your Own Death
+1 Midnight Assassin
+2 Murder
+1 Rogues' Gallery
+1 Deal Gone Bad
+2 Demon's Due
+2 Join the Maestros
+1 Daring Escape
+1 Goldhound
+3 Sticky Fingers
+1 Strangle
+1 Unlucky Witness
+3 Antagonize
 1 Light 'Em Up
-1 Maestros Diabolist
-1 Mountain
-1 Paragon of Modernity
-1 Rhox Pummeler
-1 Riveteers Overlook
-1 Shattered Seraph
-1 Spara's Adjudicators
-1 Sticky Fingers
+2 Mayhem Patrol
+2 Riveteers Initiate
+1 Rob the Archives
+2 Call In a Professional
+1 Exhibition Magician
+1 Glittering Stockpile
+2 Witty Roastmaster
+1 Hoard Hauler
+1 Plasma Jockey
+1 Sizzling Soloist
+1 Pugnacious Pugilist
+2 Attended Socialite
+1 Gala Greeters
+1 Bouncer's Beatdown
+2 Broken Wings
+1 Fight Rigging
+1 Jewel Thief
+3 Most Wanted
+1 Social Climber
+1 Topiary Stomper
+3 Warm Welcome
+1 Elegant Entourage
 1 Voice of the Vermin
+2 Freelance Muscle
+2 Cleanup Crew
+2 Rhox Pummeler
+2 Snooping Newsie
+1 Fatal Grudge
+2 Jetmir's Fixer
+1 Civil Servant
+1 Brokers Charm
+1 Disciplined Duelist
+3 Spara's Adjudicators
+1 Soul of Emancipation
+1 Nimble Larcenist
+1 Queza, Augur of Agonies
+2 Shattered Seraph
+1 Corpse Appraiser
+1 Maestros Ascendancy
+1 Maestros Diabolist
+1 Cormela, Glamour Thief
+2 Crew Captain
+1 Mr. Orfeo, the Boulder
+1 Unleash the Inferno
+1 Masked Bandits
+1 Jinnie Fay, Jetmir's Second
+2 Rakish Revelers
+1 Meeting of the Five
+2 Gilded Pinions
+1 Halo Scarab
+1 Suspicious Bookcase
+1 Chrome Cat
+3 Quick-Draw Dagger
+1 Paragon of Modernity
+1 Botanical Plaza
+1 Cabaretti Courtyard
+1 Maestros Theater
+3 Riveteers Overlook
+1 Skybridge Towers
+2 Tramway Station
+1 Waterfront District
+1 Ziatora's Proving Ground
+3 Mountain
+1 Plains
+1 Swamp

--- a/snc/pools/shiffelburger/week6.txt
+++ b/snc/pools/shiffelburger/week6.txt
@@ -1,149 +1,108 @@
-Deck
-1 Botanical Plaza (SNC) 247
-1 Brokers Hideout (SNC) 248
-1 Cabaretti Courtyard (SNC) 249
-2 Ziatora's Proving Ground (SNC) 261
-4 Forest (SNC) 271
-4 Mountain (SNC) 269
-4 Plains (SNC) 263
-1 Sticky Fingers (SNC) 124
-1 Strangle (SNC) 125
-1 Illuminator Virtuoso (SNC) 17
-1 Black Market Tycoon (SNC) 167
-2 Jetmir's Fixer (SNC) 194
-1 Park Heights Pegasus (SNC) 211
-1 Citizen's Crowbar (SNC) 8
-1 Light 'Em Up (SNC) 113
-1 Prizefight (SNC) 154
-1 Inspiring Overseer (SNC) 18
-1 Exhibition Magician (SNC) 106
-1 High-Rise Sawjack (SNC) 150
-1 Kill Shot (SNC) 19
-1 Voice of the Vermin (SNC) 163
-2 Security Rhox (SNC) 220
-1 Jetmir, Nexus of Revels (SNC) 193
-1 Capenna Express (SNC) 139
-1 Freelance Muscle (SNC) 147
-1 Rakish Revelers (SNC) 214
-1 Glittermonger (SNC) 149
-1 Luxurious Libation (SNC) 152
-
-Sideboard
-1 Boon of Safety (SNC) 4
-1 Brokers Initiate (SNC) 5
-1 Raffine's Guidance (SNC) 25
-2 Backup Agent (SNC) 2
-1 Raffine's Informant (SNC) 26
-1 Revelation of Power (SNC) 28
-1 Errant, Street Artist (SNC) 41
-1 Expendable Lackey (SNC) 43
-1 Witness Protection (SNC) 66
-2 Disdainful Stroke (SNC) 39
-2 Security Bypass (SNC) 59
-1 Obscura Initiate (SNC) 50
-3 Run Out of Town (SNC) 58
-1 Cutthroat Contender (SNC) 73
-2 Incriminate (SNC) 84
-1 Dig Up the Body (SNC) 76
-2 Murder (SNC) 88
-1 Revel Ruiner (SNC) 91
-2 Girder Goons (SNC) 80
-1 Vampire Scrivener (SNC) 98
-1 Daring Escape (SNC) 104
-1 Goldhound (SNC) 108
-1 Sticky Fingers (SNC) 124
-1 Rob the Archives (SNC) 122
-1 Pugnacious Pugilist (SNC) 117
-1 Wrecking Crew (SNC) 132
-1 Cabaretti Initiate (SNC) 137
-1 Broken Wings (SNC) 136
-2 Social Climber (SNC) 157
-1 Voice of the Vermin (SNC) 163
-2 Caldaia Strongarm (SNC) 138
-1 Exotic Pets (SNC) 185
-1 Celebrity Fencer (SNC) 7
-2 Tainted Indulgence (SNC) 227
-1 Brokers Charm (SNC) 171
-1 Nimble Larcenist (SNC) 205
-2 Shattered Seraph (SNC) 221
-1 Glamorous Outlaw (SNC) 190
-1 Arc Spitter (SNC) 233
-1 Brass Knuckles (SNC) 234
-1 Skybridge Towers (SNC) 256
-2 Tramway Station (SNC) 258
-1 Waterfront District (SNC) 259
-1 Body Dropper
-1 Caldaia Strongarm
-1 Case the Joint
-1 Corrupt Court Official
-1 Dig Up the Body
-1 Forest
-1 Forge Boss
-1 Freelance Muscle
-1 Halo Scarab
-1 High-Rise Sawjack
-1 Make Disappear
-1 Most Wanted
-1 Obscura Storefront
-1 Riveteers Decoy
-1 Void Rend
-1 Boon of Safety
-1 Botanical Plaza
-1 Celebrity Fencer
-1 Crew Captain
-1 Dapper Shieldmate
-1 Dusk Mangler
-1 Endless Detour
-1 Extract the Truth
-1 Halo Scarab
-1 Island
-1 Obscura Initiate
-1 Riveteers Overlook
-1 Rumor Gatherer
-1 Strangle
-1 Wrecking Crew
-1 Arc Spitter
-1 Broken Wings
-1 Echo Inspector
-1 Light 'Em Up
-1 Midnight Assassin
-1 Nimble Larcenist
-1 Queza, Augur of Agonies
-1 Raffine's Informant
-1 Rakish Revelers
-1 Revelation of Power
-1 Riveteers Initiate
-1 Snooping Newsie
-1 Swamp
-1 Toluz, Clever Conductor
-1 Waterfront District
-1 Botanical Plaza
-1 Civil Servant
-1 Daring Escape
-1 Disdainful Stroke
-1 Expendable Lackey
-1 Light 'Em Up
-1 Obscura Ascendancy
-1 Plains
-1 Riveteers Charm
-1 Rooftop Nuisance
-1 Shattered Seraph
-1 Social Climber
-1 Swooping Protector
-1 Tramway Station
-1 Venom Connoisseur
-1 Backstreet Bruiser
-1 Big Score
-1 Botanical Plaza
-1 Ceremonial Groundbreaker
-1 Crooked Custodian
-1 Glittering Stockpile
-1 Maestros Ascendancy
-1 Most Wanted
-1 Paragon of Modernity
+2 Boon of Safety
+1 Brokers Initiate
+1 Raffine's Guidance
+2 Backup Agent
+1 Citizen's Crowbar
+1 Illuminator Virtuoso
+2 Raffine's Informant
+2 Revelation of Power
+1 Inspiring Overseer
+1 Kill Shot
 1 Patch Up
-1 Plains
-1 Run Out of Town
-1 Social Climber
-1 Tramway Station
-1 Wrecking Crew
+1 Rumor Gatherer
+2 Celebrity Fencer
+1 Dapper Shieldmate
+1 Swooping Protector
+1 Errant, Street Artist
+2 Expendable Lackey
+1 Witness Protection
+1 Backstreet Bruiser
+3 Disdainful Stroke
+1 Make Disappear
+2 Security Bypass
+2 Obscura Initiate
+1 Rooftop Nuisance
+1 Case the Joint
+1 Echo Inspector
+4 Run Out of Town
+1 Cutthroat Contender
+1 Corrupt Court Official
+1 Crooked Custodian
+1 Extract the Truth
+2 Incriminate
+2 Dig Up the Body
+1 Midnight Assassin
+2 Murder
+1 Revel Ruiner
+2 Girder Goons
+1 Vampire Scrivener
+1 Dusk Mangler
+2 Daring Escape
+1 Goldhound
+2 Sticky Fingers
+2 Strangle
+3 Light 'Em Up
+1 Riveteers Initiate
+1 Rob the Archives
+1 Exhibition Magician
+1 Glittering Stockpile
+1 Big Score
+1 Pugnacious Pugilist
+3 Wrecking Crew
+1 Cabaretti Initiate
+1 Prizefight
+1 Riveteers Decoy
+1 Venom Connoisseur
+2 Broken Wings
+2 High-Rise Sawjack
+2 Most Wanted
+4 Social Climber
+1 Capenna Express
+1 Glittermonger
+2 Voice of the Vermin
+3 Caldaia Strongarm
+2 Freelance Muscle
+1 Luxurious Libation
+1 Exotic Pets
+1 Snooping Newsie
+2 Tainted Indulgence
+1 Body Dropper
+1 Forge Boss
+1 Black Market Tycoon
+2 Jetmir's Fixer
+2 Security Rhox
+1 Civil Servant
+1 Park Heights Pegasus
+1 Ceremonial Groundbreaker
+1 Brokers Charm
+1 Endless Detour
+2 Nimble Larcenist
+1 Obscura Ascendancy
+1 Toluz, Clever Conductor
+1 Void Rend
+1 Queza, Augur of Agonies
+3 Shattered Seraph
+1 Maestros Ascendancy
+1 Glamorous Outlaw
+1 Crew Captain
+1 Riveteers Charm
+1 Jetmir, Nexus of Revels
+2 Rakish Revelers
+2 Arc Spitter
+2 Halo Scarab
+1 Brass Knuckles
+1 Paragon of Modernity
+4 Botanical Plaza
+1 Brokers Hideout
+1 Cabaretti Courtyard
+1 Obscura Storefront
+1 Riveteers Overlook
+1 Skybridge Towers
+4 Tramway Station
+2 Waterfront District
+2 Ziatora's Proving Ground
+5 Forest
+1 Island
+4 Mountain
+6 Plains
+1 Swamp

--- a/snc/pools/warlockguest/week6.txt
+++ b/snc/pools/warlockguest/week6.txt
@@ -1,147 +1,109 @@
-1 Boon of Safety (SNC) 4
-1 Backup Agent (SNC) 2
-2 Brokers Initiate (SNC) 5
-1 Giada, Font of Hope (SNC) 14
-1 Refuse to Yield (SNC) 27
-1 Revelation of Power (SNC) 28
-1 Sky Crier (SNC) 31
-1 Inspiring Overseer (SNC) 18
-1 Kill Shot (SNC) 19
-1 Rumor Gatherer (SNC) 29
-1 Ballroom Brawlers (SNC) 3
-1 Expendable Lackey (SNC) 43
-1 Hypnotic Grifter (SNC) 45
-1 Witness Protection (SNC) 66
-2 Make Disappear (SNC) 49
-2 Majestic Metamorphosis (SNC) 48
-1 Public Enemy (SNC) 55
-2 Case the Joint (SNC) 37
-1 Echo Inspector (SNC) 40
-1 Run Out of Town (SNC) 58
-1 Sleep with the Fishes (SNC) 61
-1 Undercover Operative (SNC) 63
-2 Crooked Custodian (SNC) 71
-1 Extract the Truth (SNC) 78
-1 Maestros Initiate (SNC) 86
-2 Murder (SNC) 88
-1 Rogues' Gallery (SNC) 92
-1 Deal Gone Bad (SNC) 74
-1 Demon's Due (SNC) 75
-1 Join the Maestros (SNC) 85
-1 Daring Escape (SNC) 104
-1 Sticky Fingers (SNC) 124
-1 Strangle (SNC) 125
-3 Antagonize (SNC) 100
-1 Riveteers Initiate (SNC) 120
-1 Call In a Professional (SNC) 103
-1 Exhibition Magician (SNC) 106
-1 Professional Face-Breaker (SNC) 116
-1 Pyre-Sledge Arsonist (SNC) 118
-1 Witty Roastmaster (SNC) 131
-1 Structural Assault (SNC) 126
-2 Wrecking Crew (SNC) 132
-1 Torch Breath (SNC) 127
-1 Cabaretti Initiate (SNC) 137
-2 For the Family (SNC) 146
-1 Attended Socialite (SNC) 133
-1 Civic Gardener (SNC) 140
-1 Bouncer's Beatdown (SNC) 135
-1 Broken Wings (SNC) 136
-1 High-Rise Sawjack (SNC) 150
-1 Social Climber (SNC) 157
-1 Warm Welcome (SNC) 164
-1 Elegant Entourage (SNC) 143
-1 Glittermonger (SNC) 149
-1 Caldaia Strongarm (SNC) 138
-1 Cleanup Crew (SNC) 141
-1 Rhox Pummeler (SNC) 155
-1 Celestial Regulator (SNC) 174
-1 Exotic Pets (SNC) 185
-2 Waterfront District (SNC) 259
-1 Body Dropper (SNC) 168
-1 Security Rhox (SNC) 220
-1 Civil Servant (SNC) 176
-1 Ceremonial Groundbreaker (SNC) 175
-1 Toluz, Clever Conductor (SNC) 228
-1 Queza, Augur of Agonies (SNC) 212
-1 Mr. Orfeo, the Boulder (SNC) 204
-1 Unleash the Inferno (SNC) 229
-1 Spara's Adjudicators (SNC) 224
-1 Cabaretti Courtyard (SNC) 249
-2 Quick-Draw Dagger (SNC) 243
-1 Paragon of Modernity (SNC) 242
-1 Chrome Cat
-1 Daring Escape
-1 Glittermonger
-1 Illuminator Virtuoso
-1 Kill Shot
-1 Masked Bandits
-1 Mountain
-1 Paragon of Modernity
-1 Prizefight
-1 Raffine's Informant
-1 Revel Ruiner
-1 Sleep with the Fishes
-1 Syndicate Infiltrator
-1 Unlicensed Hearse
-1 Witness Protection
-1 Antagonize
-1 Brokers Veteran
-1 Cut Your Losses
-1 Island
-1 Join the Maestros
-1 Light 'Em Up
-1 Majestic Metamorphosis
-1 Mayhem Patrol
-1 Ominous Parcel
-1 Out of the Way
-1 Ready to Rumble
-1 Revel Ruiner
-1 Social Climber
-1 Suspicious Bookcase
-1 Venom Connoisseur
-1 Angelic Observer
-1 Brazen Upstart
-1 Cement Shoes
-1 Civil Servant
-1 Getaway Car
-1 Glamorous Outlaw
-1 Glittermonger
-1 Incriminate
-1 Island
-1 Maestros Theater
-1 Make Disappear
-1 Prizefight
-1 Snooping Newsie
-1 Warm Welcome
-1 Waterfront District
-1 Echo Inspector
+1 Boon of Safety
+2 Brokers Initiate
+1 Backup Agent
+1 Giada, Font of Hope
 1 Hold for Ransom
-1 Illicit Shipment
-1 Kill Shot
-1 Light 'Em Up
-1 Maestros Initiate
-1 Nimble Larcenist
-1 Plains
-1 Pyre-Sledge Arsonist
-1 Raffine's Informant
-1 Ready to Rumble
-1 Rigo, Streetwise Mentor
-1 Riveteers Initiate
-1 Riveteers Overlook
-1 Waterfront District
-1 Case the Joint
-1 Chrome Cat
-1 Civil Servant
-1 Crooked Custodian
+1 Illuminator Virtuoso
+2 Raffine's Informant
+1 Refuse to Yield
+1 Revelation of Power
+1 Sky Crier
+2 Inspiring Overseer
+4 Kill Shot
+1 Rumor Gatherer
 1 Dapper Shieldmate
-1 Illicit Shipment
-1 Inspiring Overseer
-1 Jetmir's Fixer
-1 Kill Shot
-1 Majestic Metamorphosis
-1 Plains
-1 Prizefight
-1 Queza, Augur of Agonies
+1 Ballroom Brawlers
+1 Angelic Observer
+1 Expendable Lackey
+1 Hypnotic Grifter
+2 Witness Protection
+1 Brokers Veteran
+3 Make Disappear
+4 Majestic Metamorphosis
+1 Public Enemy
+3 Case the Joint
+2 Echo Inspector
+1 Out of the Way
+1 Run Out of Town
+2 Sleep with the Fishes
+1 Undercover Operative
+1 Cut Your Losses
+3 Crooked Custodian
+1 Extract the Truth
+1 Incriminate
 1 Tavern Swindler
 1 Tenacious Underdog
+2 Maestros Initiate
+2 Murder
+1 Rogues' Gallery
+1 Deal Gone Bad
+1 Demon's Due
+2 Revel Ruiner
+2 Illicit Shipment
+2 Join the Maestros
+2 Daring Escape
+1 Sticky Fingers
+1 Strangle
+4 Antagonize
+2 Light 'Em Up
+1 Mayhem Patrol
+2 Riveteers Initiate
+1 Call In a Professional
+1 Exhibition Magician
+1 Professional Face-Breaker
+2 Pyre-Sledge Arsonist
+1 Witty Roastmaster
+2 Ready to Rumble
+1 Structural Assault
+2 Wrecking Crew
+1 Torch Breath
+1 Cabaretti Initiate
+2 For the Family
+1 Attended Socialite
+1 Civic Gardener
+3 Prizefight
+1 Venom Connoisseur
+1 Bouncer's Beatdown
+1 Broken Wings
+1 High-Rise Sawjack
+2 Social Climber
+2 Warm Welcome
+1 Elegant Entourage
+3 Glittermonger
+1 Caldaia Strongarm
+1 Cleanup Crew
+1 Rhox Pummeler
+1 Celestial Regulator
+1 Exotic Pets
+1 Snooping Newsie
+1 Syndicate Infiltrator
+1 Body Dropper
+1 Jetmir's Fixer
+1 Security Rhox
+3 Civil Servant
+1 Ceremonial Groundbreaker
+1 Rigo, Streetwise Mentor
+1 Spara's Adjudicators
+1 Nimble Larcenist
+1 Toluz, Clever Conductor
+2 Queza, Augur of Agonies
+1 Glamorous Outlaw
+1 Mr. Orfeo, the Boulder
+1 Unleash the Inferno
+1 Masked Bandits
+1 Brazen Upstart
+1 Cement Shoes
+1 Ominous Parcel
+1 Suspicious Bookcase
+1 Unlicensed Hearse
+2 Chrome Cat
+1 Getaway Car
+2 Quick-Draw Dagger
+2 Paragon of Modernity
+1 Cabaretti Courtyard
+1 Maestros Theater
+1 Riveteers Overlook
+4 Waterfront District
+2 Island
+1 Mountain
+2 Plains

--- a/snc/pools/yakujakku/week6.txt
+++ b/snc/pools/yakujakku/week6.txt
@@ -1,144 +1,118 @@
+1 Brokers Initiate
+2 Citizen's Crowbar
+1 Raffine's Informant
+3 Revelation of Power
+2 Sky Crier
+1 Extraction Specialist
 1 Gathering Throng
+1 Inspiring Overseer
 3 Kill Shot
-1 Revelation of Power
-1 Sky Crier
+1 Knockout Blow
+1 Swooping Protector
+1 Buy Your Silence
 1 Speakeasy Server
-1 Brokers Veteran
-1 Case the Joint
-2 Disdainful Stroke
-2 Echo Inspector
-1 Errant, Street Artist
-1 Majestic Metamorphosis
 1 An Offer You Can't Refuse
-1 Reservoir Kraken
+1 Errant, Street Artist
+1 Expendable Lackey
+1 Slip Out the Back
+1 Witness Protection
+1 Backstreet Bruiser
+3 Brokers Veteran
+2 Disdainful Stroke
+1 Make Disappear
+2 Majestic Metamorphosis
+1 Psionic Snoop
+1 Public Enemy
 1 Rooftop Nuisance
+2 Wingshield Agent
+1 Case the Joint
+3 Echo Inspector
+1 Out of the Way
+1 Reservoir Kraken
 1 Run Out of Town
 1 Sleep with the Fishes
-1 Slip Out the Back
-2 Wingshield Agent
 1 Wiretapping
 1 Cutthroat Contender
-1 Demon's Due
-1 Dig Up the Body
 1 Extract the Truth
 2 Fake Your Own Death
-1 Girder Goons
-1 Illicit Shipment
+1 Dig Up the Body
 1 Maestros Initiate
 1 Murder
-1 Whack
-1 Big Score
-1 Call In a Professional
-1 Exhibition Magician
+1 Raffine's Silencer
+2 Demon's Due
+2 Whack
+1 Girder Goons
+1 Graveyard Shift
+1 Illicit Shipment
+1 Dusk Mangler
+2 Daring Escape
 1 Goldhound
+3 Strangle
+1 Antagonize
 1 Jackhammer
 1 Light 'Em Up
-2 Riveteers Initiate
-3 Strangle
-1 Torch Breath
-1 Witty Roastmaster
-2 Wrecking Crew
-1 Caldaia Strongarm
-1 Courier's Briefcase
-1 Fight Rigging
-1 Freelance Muscle
-1 Glittermonger
-1 Jewel Thief
-1 Most Wanted
-1 Rhox Pummeler
-3 Social Climber
-1 Cabaretti Charm
-1 Corpse Appraiser
-1 Darling of the Masses
-2 Glamorous Outlaw
-1 Incandescent Aria
-1 Maestros Charm
-2 Masked Bandits
-1 Obscura Ascendancy
-1 Obscura Charm
-1 Rakish Revelers
-1 Security Rhox
-1 Cement Shoes
-1 Chrome Cat
-1 Halo Scarab
-1 Ominous Parcel
-1 Quick-Draw Dagger
-1 Brokers Hideout
-1 Obscura Storefront
-1 Racers' Ring
-1 Tramway Station
-1 Waterfront District
-1 Botanical Plaza
-1 Brokers Veteran
-1 Cabaretti Courtyard
-1 Citizen's Crowbar
-1 Echo Inspector
-1 For the Family
-1 Gilded Pinions
-1 High-Rise Sawjack
-1 Mountain
-1 Obscura Charm
-1 Plasma Jockey
-1 Ready to Rumble
-1 Revelation of Power
-1 Structural Assault
-1 Whack
-1 Botanical Plaza
-1 Brokers Initiate
-1 Citizen's Crowbar
-1 Civic Gardener
-1 Devilish Valet
-1 Dusk Mangler
-1 Expendable Lackey
-1 Inspiring Overseer
-1 Island
-1 Maestros Theater
-1 Majestic Metamorphosis
-1 Racers' Ring
-1 Sky Crier
-1 Swooping Protector
-1 Tramway Station
-1 Attended Socialite
-1 Black Market Tycoon
-1 Brazen Upstart
-1 Broken Wings
-1 Brokers Hideout
-1 Buy Your Silence
-1 Graveyard Shift
-1 Island
-1 Jewel Thief
-1 Knockout Blow
-1 Make Disappear
-1 Psionic Snoop
-1 Ready to Rumble
-1 Revelation of Power
-1 Witness Protection
-1 Antagonize
-1 Broken Wings
-1 Cabaretti Charm
-1 Cabaretti Initiate
-1 Chrome Cat
-1 Daring Escape
-1 Extraction Specialist
-1 Nimble Larcenist
-1 Out of the Way
-1 Raffine's Informant
-1 Shattered Seraph
-1 Swamp
-2 Tramway Station
-1 Warm Welcome
-1 Backstreet Bruiser
-1 Brokers Veteran
-1 Courier's Briefcase
-1 Daring Escape
-1 Demon's Due
-1 Jetmir's Fixer
 1 Mayhem Patrol
-1 Most Wanted
-1 Plains
-1 Public Enemy
-1 Raffine's Silencer
-1 Rakish Revelers
+2 Riveteers Initiate
+1 Call In a Professional
+1 Devilish Valet
+1 Exhibition Magician
+1 Witty Roastmaster
+1 Big Score
+1 Plasma Jockey
+2 Ready to Rumble
+1 Structural Assault
+2 Wrecking Crew
+1 Torch Breath
+1 Cabaretti Initiate
+1 For the Family
+1 Attended Socialite
+1 Civic Gardener
+2 Courier's Briefcase
+2 Broken Wings
+1 Fight Rigging
+1 High-Rise Sawjack
+2 Jewel Thief
+2 Most Wanted
+3 Social Climber
+1 Warm Welcome
+1 Glittermonger
+1 Caldaia Strongarm
+1 Freelance Muscle
+1 Rhox Pummeler
 1 Snooping Newsie
+1 Black Market Tycoon
+1 Jetmir's Fixer
+1 Security Rhox
+1 Darling of the Masses
 1 Spara's Adjudicators
+1 Nimble Larcenist
+1 Obscura Ascendancy
+2 Obscura Charm
+1 Shattered Seraph
+1 Corpse Appraiser
+1 Maestros Charm
+2 Glamorous Outlaw
+2 Masked Bandits
 1 Ziatora, the Incinerator
+1 Brazen Upstart
+2 Cabaretti Charm
+1 Incandescent Aria
+2 Rakish Revelers
+1 Cement Shoes
+1 Ominous Parcel
+1 Gilded Pinions
+1 Halo Scarab
+2 Chrome Cat
+1 Quick-Draw Dagger
+2 Botanical Plaza
+2 Brokers Hideout
+1 Cabaretti Courtyard
+1 Maestros Theater
+1 Obscura Storefront
+2 Racers' Ring
+4 Tramway Station
+1 Waterfront District
+2 Island
+1 Mountain
+1 Plains
+1 Swamp


### PR DESCRIPTION
Week 6 pools were in a couple of different formats, contained multiple entries for the same card, and some cards had`(SNC)` and the card number from the set. 

This PR runs each pool through [sealeddeck.tech](https://sealeddeck.tech/) to merge any duplicates and standardizes the pool format (just a list of cards, no deck/sideboard nonsense)